### PR TITLE
Fixes issue with 100%FREE being unescaped

### DIFF
--- a/teamcity-server.yaml
+++ b/teamcity-server.yaml
@@ -216,7 +216,7 @@ Resources:
                               ExecStart=/bin/bash -c \
                               '/usr/sbin/pvcreate /dev/xvdg && \
                               /usr/sbin/vgcreate app /dev/xvdg && \
-                              /usr/sbin/lvcreate -l 100%FREE -n data app && \
+                              /usr/sbin/lvcreate -l 100%%FREE -n data app && \
                               /usr/sbin/mkfs.ext4 /dev/mapper/app-data'
 
                             [Install]


### PR DESCRIPTION
SystemD uses % as the keyword for internal format specifiers. 
This makes startup fail with error:
systemd[1]:
/etc/systemd/system/format-mnt-data.service:8: Failed to resolve unit
specifiers on /usr/sbin/pvcreate /dev/xvdg &&    /usr/sbin/vgcreate app
/dev/xvdg &&    /usr/sbin/lvcreate -l 100%FREE -n data app &&
/usr/sbin/mkfs.ext4 /dev/mapper/app-data: Invalid slot