### PR TITLE
Export PublicElb URL To Allow CrossStack Reference

### DIFF
--- a/teamcity-server.yaml
+++ b/teamcity-server.yaml
@@ -1021,6 +1021,12 @@ Outputs:
   TeamCityServerUrl:
     Description: TeamCity Server URL
     Value: !Join ["", [ !If [ShouldRequestCertificate, "https://", "http://" ] , !GetAtt [PublicLoadBalancer, DNSName], "/" ]]
+    
+  PublicLoadBalancerUrl:
+    Description: URL of Public ELB
+    Value: !GetAtt [PublicLoadBalancer, DNSName]
+    Export:
+      Name: !Sub "${AWS::StackName}-public-elb-url"
 
   SSHBastionHostIP:
     Description: SSH Bastion Host IP


### PR DESCRIPTION
When creating the stack, and you define a domain for use with SSL, the current Output value of `TeamCityServerUrl` references the public ELB DNS address. This is fine for access but breaks most browsers since when accessing `teamc-publi-xxxxx-xxxxx.us-west-x.elb.amazonaws.com` SSL breaks since the domain you are requesting is not what the SSL cert is using.

In our case, all we need to do is add a Route 53 Alias in the same HostedZone we used for the domain of the SSL cert and the SSL "issues" go away.

To do this dynamically we would need the ELB DNS name to Exported such that we can import into our existing stacks.

Does this make sense?

Thanks in advance.