### PR TITLE
Fix cfn-python-lint errors and warnings

### DIFF
--- a/teamcity-server-ha.yaml
+++ b/teamcity-server-ha.yaml
@@ -446,7 +446,6 @@ Resources:
 
   NatGatewayRoute1:
     Type: AWS::EC2::Route
-    DependsOn: NatGateway
     Properties:
       RouteTableId: !Ref PrivateRouteTable1
       DestinationCidrBlock: 0.0.0.0/0
@@ -454,7 +453,6 @@ Resources:
 
   NatGatewayRoute2:
     Type: AWS::EC2::Route
-    DependsOn: NatGateway
     Properties:
       RouteTableId: !Ref PrivateRouteTable2
       DestinationCidrBlock: 0.0.0.0/0
@@ -468,12 +466,12 @@ Resources:
       SecurityGroupIngress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: "tcp"
-          FromPort: "443"
-          ToPort: "443"
+          FromPort: 443
+          ToPort: 443
         - CidrIp: 0.0.0.0/0
           IpProtocol: "tcp"
-          FromPort: "80"
-          ToPort: "80"
+          FromPort: 80
+          ToPort: 80
 
   AllAccessSG:
     Type: AWS::EC2::SecurityGroup
@@ -482,20 +480,16 @@ Resources:
       VpcId: !Ref 'VPC'
       SecurityGroupIngress:
         - CidrIp: 0.0.0.0/0
-          IpProtocol: -1
+          IpProtocol: "-1"
 
   FrontendSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    DependsOn:
-      - VPC
     Properties:
       GroupDescription: Frontends
       VpcId: !Ref 'VPC'
 
   FrontendSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
-    DependsOn:
-      - FrontendSecurityGroup
     Properties:
       SourceSecurityGroupId:
         Fn::GetAtt:
@@ -505,20 +499,16 @@ Resources:
         Fn::GetAtt:
         - FrontendSecurityGroup
         - GroupId
-      IpProtocol: -1
+      IpProtocol: "-1"
 
   BackendSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    DependsOn:
-      - VPC
     Properties:
       GroupDescription: Backends
       VpcId: !Ref 'VPC'
 
   BackendSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
-    DependsOn:
-      - BackendSecurityGroup
     Properties:
       SourceSecurityGroupId:
         Fn::GetAtt:
@@ -528,13 +518,10 @@ Resources:
         Fn::GetAtt:
         - BackendSecurityGroup
         - GroupId
-      IpProtocol: -1
+      IpProtocol: "-1"
 
   FrontendAccessIngress:
       Type: 'AWS::EC2::SecurityGroupIngress'
-      DependsOn:
-        - FrontendSecurityGroup
-        - BackendSecurityGroup
       Properties:
         SourceSecurityGroupId:
           Fn::GetAtt:
@@ -544,7 +531,7 @@ Resources:
           Fn::GetAtt:
           - BackendSecurityGroup
           - GroupId
-        IpProtocol: -1
+        IpProtocol: "-1"
 
   PublicLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -642,8 +629,6 @@ Resources:
 
   PublicLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn:
-      - PublicLoadBalancer
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref FrontendTargetGroup
@@ -667,8 +652,6 @@ Resources:
 
   TCMainNodeLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn:
-      - TCMainNodeLoadBalancer
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref MainServerNodeTargetGroup
@@ -692,8 +675,6 @@ Resources:
 
   TCRONodeLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn:
-      - TCRONodeLoadBalancer
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref ReadonlyServerNodeTargetGroup
@@ -727,13 +708,13 @@ Resources:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
       LaunchConfigurationName: !Ref "FrontendLaunchConfiguration"
-      MinSize: 1
-      MaxSize: 3
-      DesiredCapacity: 2
+      MinSize: "1"
+      MaxSize: "3"
+      DesiredCapacity: "2"
       Tags:
         - Key: teamcity.node-responsibility
           Value: frontend
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
   BackendAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -745,13 +726,13 @@ Resources:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
       LaunchConfigurationName: !Ref "BackendLaunchConfiguration"
-      MinSize: 2
-      MaxSize: 2
-      DesiredCapacity: 2
+      MinSize: "2"
+      MaxSize: "2"
+      DesiredCapacity: "2"
       Tags:
         - Key: teamcity.node-responsibility
           Value: backend
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
   AgentAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -767,7 +748,7 @@ Resources:
       Tags:
         - Key: teamcity.node-responsibility
           Value: buildAgent
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
   FrontendLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -898,8 +879,6 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     DependsOn:
       - PublicLoadBalancer
-      - TCMainNodeLoadBalancer
-      - TCRONodeLoadBalancer
     Properties:
       PlacementConstraints:
         - Type: memberOf
@@ -933,9 +912,6 @@ Resources:
 
   MainServerNodeTaskDefinition:
     Type: AWS::ECS::TaskDefinition
-    DependsOn:
-      - RDSDB
-      - ServerMemory
     Properties:
       PlacementConstraints:
         - Type: memberOf
@@ -963,8 +939,7 @@ Resources:
               - "if [ ! -f /data/teamcity_server/datadir/lib/jdbc ]; then mkdir -p /data/teamcity_server/datadir/lib/jdbc; curl -o /data/teamcity_server/datadir/lib/jdbc/mysql-connector-java-bin.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.43/mysql-connector-java-5.1.43.jar; fi; if [ ! -f /data/teamcity_server/datadir/config/database.properties ]; then mkdir -p /data/teamcity_server/datadir/config; echo connectionProperties.user=teamcity > /data/teamcity_server/datadir/config/database.properties; echo connectionProperties.password='${RDSPassword}' >> /data/teamcity_server/datadir/config/database.properties; echo connectionUrl=jdbc:mysql://${RDSAddress}/teamcitydb >> /data/teamcity_server/datadir/config/database.properties; fi; if [ ! -f /data/teamcity_server/datadir/plugins ]; then mkdir -p /data/teamcity_server/datadir/plugins; curl -o /data/teamcity_server/datadir/plugins/aws-ecs.zip https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:TestDrive_TeamCityAmazonEcsPlugin_Build20172x,tag:release/artifacts/content/aws-ecs.zip; fi; echo 'docker-ubuntu-aws' > /opt/teamcity/webapps/ROOT/WEB-INF/DistributionType.txt; exec /run-services.sh;"
               - {
                   RDSAddress: !GetAtt [RDSDB, Endpoint.Address],
-                  RDSPassword: !Ref 'DBPassword',
-                  TeamCityVersion: !Ref 'TeamCityVersion'
+                  RDSPassword: !Ref 'DBPassword'
                 }
           Environment:
             - Name: TEAMCITY_SERVER_MEM_OPTS
@@ -991,9 +966,6 @@ Resources:
 
   ReadonlyServerNodeTaskDefinition:
     Type: AWS::ECS::TaskDefinition
-    DependsOn:
-      - RDSDB
-      - ServerMemory
     Properties:
       PlacementConstraints:
         - Type: memberOf
@@ -1024,8 +996,7 @@ Resources:
               - "if [ ! -f /data/teamcity_server_ro/datadir/lib/jdbc ]; then mkdir -p /data/teamcity_server_ro/datadir/lib/jdbc; curl -o /data/teamcity_server_ro/datadir/lib/jdbc/mysql-connector-java-bin.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.43/mysql-connector-java-5.1.43.jar; fi; if [ ! -f /data/teamcity_server_ro/datadir/config/database.properties ]; then mkdir -p /data/teamcity_server_ro/datadir/config; echo connectionProperties.user=teamcity > /data/teamcity_server_ro/datadir/config/database.properties; echo connectionProperties.password='${RDSPassword}' >> /data/teamcity_server_ro/datadir/config/database.properties; echo connectionUrl=jdbc:mysql://${RDSAddress}/teamcitydb >> /data/teamcity_server_ro/datadir/config/database.properties; fi; if [ ! -f /data/teamcity_server_ro/datadir/plugins ]; then mkdir -p /data/teamcity_server_ro/datadir/plugins; curl -o /data/teamcity_server_ro/datadir/plugins/aws-ecs.zip https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:TestDrive_TeamCityAmazonEcsPlugin_Build20172x,tag:release/artifacts/content/aws-ecs.zip; fi; echo 'docker-ubuntu-aws' > /opt/teamcity/webapps/ROOT/WEB-INF/DistributionType.txt; exec /run-services.sh;"
               - {
                   RDSAddress: !GetAtt [RDSDB, Endpoint.Address],
-                  RDSPassword: !Ref 'DBPassword',
-                  TeamCityVersion: !Ref 'TeamCityVersion'
+                  RDSPassword: !Ref 'DBPassword'
                 }
           Environment:
             - Name: TEAMCITY_SERVER_OPTS
@@ -1058,7 +1029,6 @@ Resources:
       Type: AWS::ECS::TaskDefinition
       Condition: ShouldLaunchAgents
       DependsOn:
-        - PublicLoadBalancer
         - MainServerNodeService
       Properties:
         PlacementConstraints:
@@ -1225,10 +1195,10 @@ Resources:
           GroupDescription: SSH access SG
           VpcId: !Ref 'VPC'
           SecurityGroupIngress:
-            - IpProtocol: tcp
-              FromPort: '22'
-              ToPort: '22'
-              CidrIp: 0.0.0.0/0
+            - IpProtocol: "tcp"
+              FromPort: 22
+              ToPort: 22
+              CidrIp: "0.0.0.0/0"
 
   # RDS
 
@@ -1256,7 +1226,7 @@ Resources:
       VpcId: !Ref 'VPC'
       GroupDescription: !Sub TeamCity ${AWS::StackName} Database
       SecurityGroupIngress:
-        - IpProtocol: -1
+        - IpProtocol: "-1"
           SourceSecurityGroupId:
             Fn::GetAtt:
             - BackendSecurityGroup
@@ -1299,9 +1269,6 @@ Resources:
   SecuredLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: ShouldRequestCertificate
-    DependsOn:
-      - PublicLoadBalancer
-      - Certificate
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref FrontendTargetGroup
@@ -1316,8 +1283,6 @@ Resources:
   # Utils
   ServerMemory:
     Type: Custom::ServerMemory
-    DependsOn:
-      - ServerMemoryFunction
     Properties:
       ServiceToken: !GetAtt ServerMemoryFunction.Arn
       Region: !Ref "AWS::Region"
@@ -1325,11 +1290,9 @@ Resources:
 
   ServerMemoryFunction:
     Type: AWS::Lambda::Function
-    DependsOn:
-      - LambdaExecutionRole
     Properties:
       Code:
-        ZipFile: !Sub |
+        ZipFile: |
           var response = require('cfn-response');
           exports.lambda_handler = function(event, context) {
             var input = parseInt(event.ResourceProperties.Input);
@@ -1368,9 +1331,9 @@ Resources:
       VpcId: !Ref 'VPC'
       SecurityGroupIngress:
         - CidrIp: !Ref SshAccessSourceIPRange
-          IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
+          IpProtocol: "tcp"
+          FromPort: 22
+          ToPort: 22
 
   SshBastionHostInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -1441,13 +1404,13 @@ Resources:
         - !Ref PublicSubnet1
         - !Ref PublicSubnet2
       LaunchConfigurationName: !Ref "SshBastionHostLaunchConfiguration"
-      MinSize: 1
-      MaxSize: 1
-      DesiredCapacity: !If [EnableExternalSshAccess, 1, 0]
+      MinSize: "1"
+      MaxSize: "1"
+      DesiredCapacity: !If [EnableExternalSshAccess, "1", "0"]
       Tags:
         - Key: teamcity.node-responsibility
           Value: ssh-bastion-host
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
 Outputs:
   HATeamCityServerUrl:

--- a/teamcity-server.yaml
+++ b/teamcity-server.yaml
@@ -406,7 +406,6 @@ Resources:
 
   NatGatewayRoute1:
     Type: AWS::EC2::Route
-    DependsOn: NatGateway
     Properties:
       RouteTableId: !Ref PrivateRouteTable1
       DestinationCidrBlock: 0.0.0.0/0
@@ -414,7 +413,6 @@ Resources:
 
   NatGatewayRoute2:
     Type: AWS::EC2::Route
-    DependsOn: NatGateway
     Properties:
       RouteTableId: !Ref PrivateRouteTable2
       DestinationCidrBlock: 0.0.0.0/0
@@ -468,12 +466,12 @@ Resources:
       SecurityGroupIngress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: "tcp"
-          FromPort: "443"
-          ToPort: "443"
+          FromPort: 443
+          ToPort: 443
         - CidrIp: 0.0.0.0/0
           IpProtocol: "tcp"
-          FromPort: "80"
-          ToPort: "80"
+          FromPort: 80
+          ToPort: 80
 
   AllAccessSG:
     Type: AWS::EC2::SecurityGroup
@@ -482,7 +480,7 @@ Resources:
       VpcId: !Ref 'VPC'
       SecurityGroupIngress:
         - CidrIp: 0.0.0.0/0
-          IpProtocol: -1
+          IpProtocol: "-1"
 
   PublicLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -518,8 +516,6 @@ Resources:
 
   PublicLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn:
-      - PublicLoadBalancer
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref TCServerNodeTargetGroup
@@ -540,13 +536,13 @@ Resources:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
       LaunchConfigurationName: !Ref "TCServerLaunchConfiguration"
-      MinSize: 1
-      MaxSize: 1
-      DesiredCapacity: 1
+      MinSize: "1"
+      MaxSize: "1"
+      DesiredCapacity: "1"
       Tags:
         - Key: teamcity.node-responsibility
           Value: server
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
   AgentAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -562,7 +558,7 @@ Resources:
       Tags:
         - Key: teamcity.node-responsibility
           Value: buildAgent
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
   TCServerAccessSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -573,7 +569,7 @@ Resources:
   TCServerSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      IpProtocol: -1
+      IpProtocol: "-1"
       GroupId:
         Fn::GetAtt:
           - TCServerAccessSecurityGroup
@@ -654,9 +650,6 @@ Resources:
 
   TCServerNodeTaskDefinition:
     Type: AWS::ECS::TaskDefinition
-    DependsOn:
-      - RDSDB
-      - ServerMemory
     Properties:
       PlacementConstraints:
         - Type: memberOf
@@ -684,8 +677,7 @@ Resources:
               - "if [ ! -f /data/teamcity_server/datadir/lib/jdbc ]; then mkdir -p /data/teamcity_server/datadir/lib/jdbc; curl -o /data/teamcity_server/datadir/lib/jdbc/mysql-connector-java-bin.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.43/mysql-connector-java-5.1.43.jar; fi; if [ ! -f /data/teamcity_server/datadir/config/database.properties ]; then mkdir -p /data/teamcity_server/datadir/config; echo connectionProperties.user=teamcity > /data/teamcity_server/datadir/config/database.properties; echo connectionProperties.password=${RDSPassword} >> /data/teamcity_server/datadir/config/database.properties; echo connectionUrl=jdbc:mysql://${RDSAddress}/teamcitydb >> /data/teamcity_server/datadir/config/database.properties; fi; if [ ! -f /data/teamcity_server/datadir/plugins ]; then mkdir -p /data/teamcity_server/datadir/plugins; curl -o /data/teamcity_server/datadir/plugins/aws-ecs.zip https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:TestDrive_TeamCityAmazonEcsPlugin_Build20172x,tag:release/artifacts/content/aws-ecs.zip; fi; echo 'docker-ubuntu-aws' > /opt/teamcity/webapps/ROOT/WEB-INF/DistributionType.txt; exec /run-services.sh;"
               - {
                   RDSAddress: !GetAtt [RDSDB, Endpoint.Address],
-                  RDSPassword: !Ref 'DBPassword',
-                  TeamCityVersion: !Ref 'TeamCityVersion'
+                  RDSPassword: !Ref 'DBPassword'
                 }
           Environment:
             - Name: TEAMCITY_SERVER_MEM_OPTS
@@ -714,7 +706,6 @@ Resources:
       Type: AWS::ECS::TaskDefinition
       Condition: ShouldLaunchAgents
       DependsOn:
-        - PublicLoadBalancer
         - TCServerNodeService
       Properties:
         PlacementConstraints:
@@ -786,8 +777,8 @@ Resources:
           VpcId: !Ref 'VPC'
           SecurityGroupIngress:
             - IpProtocol: tcp
-              FromPort: '22'
-              ToPort: '22'
+              FromPort: 22
+              ToPort: 22
               CidrIp: 0.0.0.0/0
 
   # RDS
@@ -819,7 +810,7 @@ Resources:
   RDSSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      IpProtocol: -1
+      IpProtocol: "-1"
       GroupId:
         Fn::GetAtt:
           - RDSSecurityGroup
@@ -866,9 +857,6 @@ Resources:
   SecuredLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: ShouldRequestCertificate
-    DependsOn:
-      - PublicLoadBalancer
-      - Certificate
     Properties:
       DefaultActions:
         - TargetGroupArn: !Ref TCServerNodeTargetGroup
@@ -883,8 +871,6 @@ Resources:
   # Utils
   ServerMemory:
     Type: Custom::ServerMemory
-    DependsOn:
-      - ServerMemoryFunction
     Properties:
       ServiceToken: !GetAtt ServerMemoryFunction.Arn
       Region: !Ref "AWS::Region"
@@ -892,11 +878,9 @@ Resources:
 
   ServerMemoryFunction:
     Type: AWS::Lambda::Function
-    DependsOn:
-      - LambdaExecutionRole
     Properties:
       Code:
-        ZipFile: !Sub |
+        ZipFile: |
           var response = require('cfn-response');
           exports.lambda_handler = function(event, context) {
             var input = parseInt(event.ResourceProperties.Input);
@@ -936,8 +920,8 @@ Resources:
       SecurityGroupIngress:
         - CidrIp: !Ref SshAccessSourceIPRange
           IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
+          FromPort: 22
+          ToPort: 22
 
   SshBastionHostInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -1008,13 +992,13 @@ Resources:
         - !Ref PublicSubnet1
         - !Ref PublicSubnet2
       LaunchConfigurationName: !Ref "SshBastionHostLaunchConfiguration"
-      MinSize: 1
-      MaxSize: 1
-      DesiredCapacity: !If [EnableExternalSshAccess, 1, 0]
+      MinSize: "1"
+      MaxSize: "1"
+      DesiredCapacity: !If [EnableExternalSshAccess, "1", "0"]
       Tags:
         - Key: teamcity.node-responsibility
           Value: ssh-bastion-host
-          PropagateAtLaunch: 'true'
+          PropagateAtLaunch: true
 
 
 Outputs:
@@ -1025,4 +1009,3 @@ Outputs:
   SSHBastionHostIP:
     Description: SSH Bastion Host IP
     Value: !If [EnableExternalSshAccess, !Ref SshBastionHostPublicEIP, 'not provided']
-


### PR DESCRIPTION
Ran the latest version of the "AWS CloudFormation Linter" ([cfn-python-lint](https://github.com/aws-cloudformation/cfn-python-lint)) on the templates.

**cfn-python-lint**
`cfn-python-lint` is an Open Source project from AWS which performance enhanced static file analysis on CloudFormation templates, based on e.g. the [CloudFormation Resource Specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html). It applies more than 100 different rules to check for breaking changes and best practises.

This PR fixes all the findings and makes the template "better"