### PR TITLE
nodejs runtime update

### DIFF
--- a/teamcity-server-ha.yaml
+++ b/teamcity-server-ha.yaml
@@ -1300,7 +1300,7 @@ Resources:
             response.send(event, context, response.SUCCESS, responseData);
           }
       Handler: "index.lambda_handler"
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
 

--- a/teamcity-server.yaml
+++ b/teamcity-server.yaml
@@ -888,7 +888,7 @@ Resources:
             response.send(event, context, response.SUCCESS, responseData);
           }
       Handler: "index.lambda_handler"
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
 


### PR DESCRIPTION
nodejs8.10 is no longer supported as runtime for AWS Lambda